### PR TITLE
Feature/fix search compare lings scenario

### DIFF
--- a/app/assets/templates/searches/results/compare_results.hamstache
+++ b/app/assets/templates/searches/results/compare_results.hamstache
@@ -1,7 +1,7 @@
 {{#commons}}
 #tableCommonHeader
   %h3.red_grad Properties in Common {{lings}}:
-%table.show-table.table.table-bordered.table-striped.table-hover
+%table#tableCommon.show-table.table.table-bordered.table-striped.table-hover
   %thead
     %tr
       {{#header.commons.compare_property}}
@@ -24,7 +24,7 @@
 {{#differents}}
 #tableNotCommonHeader
   %h3.red_grad Properties not in Common:
-%table.show-table.table.table-bordered.table-striped.table-hover
+%table#tableNotCommon.show-table.table.table-bordered.table-striped.table-hover
   %thead
     %tr
       {{#header.differents.compare_property}}

--- a/app/assets/templates/searches/results/compare_results.hamstache
+++ b/app/assets/templates/searches/results/compare_results.hamstache
@@ -12,7 +12,7 @@
       {{/header.commons.common_values}}
   %tbody
     {{#rows.commons}}
-    %tr
+    %tr.search_common_result
       {{#compare_property}}
       %td {{compare_property}}
       {{/compare_property}}
@@ -35,7 +35,7 @@
       {{/header.differents.ling_value}}
   %tbody
     {{#rows.differents}}
-    %tr
+    %tr.search_diff_result
       {{#compare_property}}
       %td {{compare_property}}
       {{/compare_property}}

--- a/app/presenters/search_json.rb
+++ b/app/presenters/search_json.rb
@@ -43,22 +43,26 @@ class SearchJSON
     entry[:commons] = Hash.new
     # common results
     commons  = results_in_common_compare_search(rows)
-    result_headers(value_for_header(commons)).each do |key_value|
-      entry[:commons][key_value[:key]] = key_value[:value].call( @search.group )
+    unless commons.empty?
+      result_headers(value_for_header(commons)).each do |key_value|
+        entry[:commons][key_value[:key]] = key_value[:value].call( @search.group )
+      end
     end
-    
+
     # diff results
     entry[:differents] = Hash.new
     differents = results_diff_compare_search(rows)
-    values_for_header = value_for_header(differents)
-    diff_headers = result_headers(values_for_header)
+    unless differents.empty?
+      values_for_header = value_for_header(differents)
+      diff_headers = result_headers(values_for_header)
 
-    # First column: this is the property column
-    entry[:differents][diff_headers[0][:key]] = diff_headers[0][:value].call( @search.group )
-    # Other columns: one column per language here
-    entry[:differents][diff_headers[1][:key]] = Array.new
-    values_for_header.each do |value|
-      entry[:differents][diff_headers[1][:key]] << diff_headers[1][:value].call(value)
+      # First column: this is the property column
+      entry[:differents][diff_headers[0][:key]] = diff_headers[0][:value].call( @search.group )
+      # Other columns: one column per language here
+      entry[:differents][diff_headers[1][:key]] = Array.new
+      values_for_header.each do |value|
+        entry[:differents][diff_headers[1][:key]] << diff_headers[1][:value].call(value)
+      end
     end
   end
 

--- a/features/search_compare_lings.feature
+++ b/features/search_compare_lings.feature
@@ -104,7 +104,6 @@ Feature: Search Lings for Compare Property
     And I select "Italian 1" from "Speakers"
     And I select "French 1" from "Speakers"
     And I choose "Compare" within "#languages"
-    And I choose "Compare" within "#speakers"
     And I press "Show results"
     Then I should see "Results"
     Then I should see 1 properties in common


### PR DESCRIPTION
@hab278 @dej611 

All the following commits are made for fixing all problems in features/search_compare_lings.feature:
- I added somme `classes` and `ids` in compare_results.hamstache because in some steps of search_compare_lings.feature can't find them
- I added a unless condition for the `common` and `differents` variable, because when common was empty it raised an error
- I delete one step on the last scenario of search_compare_lings.feature because after you click in "compare" radio button of languages scope, you can't click the other "compare" radio button of speakers scope. I think is blocked by javascript
