### PR TITLE
Fixed saved_search.feature

### DIFF
--- a/app/assets/javascripts/views/searches/preview.js
+++ b/app/assets/javascripts/views/searches/preview.js
@@ -238,6 +238,8 @@
       setBar(100, 'Preparing the results');
     }
 
+    setDataResultGroups(json);
+
     setTimeout(function(){
 
       // cache it for later reuse
@@ -251,6 +253,32 @@
       }
       
     }, 500);
+  }
+
+  function setDataResultGroups(json){
+    switch (json.type) {
+      case "default":
+        result_groups = DefaultSearchResultGroups(json);
+        break;
+      default:
+        result_groups = "{}";
+    }
+    $('#search_results').data('result-groups', result_groups);
+  }
+
+  function DefaultSearchResultGroups(json) {
+    var result_groups = {};
+    for( var i=0; i < json.rows.length; i++){
+      row = json.rows[i];
+      ling_parent_id = row.parent.lings_property.ling_id.toString();
+      ling_child_id = row.child.lings_property.ling_id.toString();
+      if (result_groups[ling_parent_id] == null) {
+        result_groups[ling_parent_id] = [ling_child_id];
+      } else {
+        result_groups[ling_parent_id].push(ling_child_id);
+      }
+    }
+    return result_groups;
   }
 
   function setType(type){

--- a/app/assets/javascripts/views/searches/results/results_cross.js
+++ b/app/assets/javascripts/views/searches/results/results_cross.js
@@ -71,17 +71,21 @@
 
     function mapCrossHeaders(){
       var headers = resultsJson.header;
-      var row = resultsJson.rows[0].parent;
-
       var result = {headers: [], header: {count: headers.count }, rows: []};
-      for( var i =0; i<row.length; i++){
-        var header = {};
-        for( var h in headers){
-          if(headers.hasOwnProperty(h) && h !== 'count'){
-            header[h] = headers[h];
+
+      if (resultsJson.rows[0]) {
+        var row = resultsJson.rows[0].parent;
+        for( var i =0; i<row.length; i++){
+          var header = {};
+          for( var h in headers){
+            if(headers.hasOwnProperty(h) && h !== 'count'){
+              header[h] = headers[h];
+            }
           }
+          result.headers.push(header);
         }
-        result.headers.push(header);
+      } else {
+        result["headers"] = headers;
       }
       return result;
     }

--- a/app/assets/javascripts/views/searches/results/save_search.js
+++ b/app/assets/javascripts/views/searches/results/save_search.js
@@ -27,26 +27,30 @@
     function onSubmit(){
       // don't worry: in case it's forced the server will reject it anyway
       $('#save-form').on('submit', function (e){
-        var params = $(this).serialize();
-        
-        $('#save-search')
-          .button('loading')
-          .attr('disabled', true);
-
         // Prevent page change: use AJAX power!
         e.preventDefault();
+        if ($("input#save-search-name").val()) {
+          $("#blank-error").hide();
+          var params = $(this).serialize();
+          $('#save-search')
+            .button('loading')
+            .attr('disabled', true);
 
-        saveSearch(params);
-        
+          saveSearch(params);
+        } else {
+          $("#blank-error").show();
+        }
       });
     }
 
     function showModal(){
 
       var queryJsonString = $('#search_results').data('query');
+      var resultGroupsJsonString = $('#search_results').data('result-groups');
 
       // add search query
       $('[name="search[query_json]"]').val(JSON.stringify(queryJsonString));
+      $('[name="search[result_groups_json]"]').val(JSON.stringify(resultGroupsJsonString));
 
       // enable the save button in case it was disabled
       $('#save-search').attr('disabled', false);

--- a/app/presenters/search_columns.rb
+++ b/app/presenters/search_columns.rb
@@ -80,12 +80,17 @@ module SearchColumns
 
   # This method will scale the number of columns based of Property choosen
   def scale_cross_columns
-    name, value, count = CROSS_COLUMNS
-    props = @search.results.first.parent
-    [].tap do |columns_to_show|
-      props.each {|p| columns_to_show << [name, value] }
-      columns_to_show << count
-    end.flatten
+    search_results = @search.results
+    if search_results.empty?
+      CROSS_COLUMNS
+    else
+      name, value, count = CROSS_COLUMNS
+      props = search_results.first.parent
+      [].tap do |columns_to_show|
+        props.each {|p| columns_to_show << [name, value] }
+        columns_to_show << count
+      end.flatten
+    end
   end
 
   def result_headers_compare(entry)

--- a/app/views/searches/_dynamic_results.html.haml
+++ b/app/views/searches/_dynamic_results.html.haml
@@ -1,7 +1,7 @@
 .row
   = render :partial => 'searches/results_navbar'
 #results-wrapper
-  #search_results.padded_left.padded_right{:data => {:query => @query, :search_id => "#{@search.name ? @search.id : 'null'}" }}
+  #search_results.padded_left.padded_right{:data => {:query => @query, :result_groups => "", :search_id => "#{@search.name ? @search.id : 'null'}" }}
     .apple_pagination.js-pagination
     #paginated-results
       %p#results_loading_text.strong{ :style => 'text-align: center;'}

--- a/app/views/searches/_save_search_form.html.haml
+++ b/app/views/searches/_save_search_form.html.haml
@@ -17,6 +17,8 @@
                       = pluralize(@search.errors.count, "error")
                       prohibited this search from being saved:
                     %ul#error-message
+                  #blank-error.col-8-md.alert.alert-danger{:style => "display: none;"}
+                    %p The Search name can't be blank
                   #success-explanation.col-8-md.alert.alert-success{:style => "display: none;"}
                     %p Your seach has been successfully saved!
               .form-group

--- a/app/views/searches/_save_search_form.html.haml
+++ b/app/views/searches/_save_search_form.html.haml
@@ -4,7 +4,7 @@
       .modal-content
         = content_tag :fieldset do
           .modal-header
-            %button.close{ :type => "button", :data => { :dismiss => "modal"}, :aria => { :hidden => "true" }} ×
+            %button#close_modal.close{ :type => "button", :data => { :dismiss => "modal"}, :aria => { :hidden => "true" }} ×
             %button#minimize.close{ :type => "button", :aria => { :hidden => "true"}} -&nbsp;
             %span#modal-head-content
               %h3 Save search results
@@ -37,7 +37,7 @@
     .modal-content
       = content_tag :fieldset do
         .modal-header
-          %button.close{ :type => "button", :data => { :dismiss => "modal"}, :aria => { :hidden => "true" }} ×
+          %button#close_modal.close{ :type => "button", :data => { :dismiss => "modal"}, :aria => { :hidden => "true" }} ×
           %button#minimize.close{ :type => "button", :aria => { :hidden => "true"}} -&nbsp;
           %span#modal-head-content
             %h3 Download search results

--- a/features/saved_searches.feature
+++ b/features/saved_searches.feature
@@ -33,13 +33,13 @@ Feature: Save searches
   Scenario: No link to search history if signed out
     Given I have a saved group search "My First Search"
     When I go to the Syntactic Structures search page
-    And I follow "Sign Out"
+    And I follow "Sign out"
     And I go to the Syntactic Structures search page
     Then I should not see "History"
 
   Scenario: No save search form if signed out
     When I go to the Syntactic Structures search page
-    And I follow "Sign Out"
+    And I follow "Sign out"
     And I go to the Syntactic Structures search page
     And I select "Speaker 1" from "Speakers"
     And I select "Sentence 1" from "Sentences"

--- a/features/saved_searches.feature
+++ b/features/saved_searches.feature
@@ -1,8 +1,7 @@
 Feature: Save searches
 
   Background:
-    Given I am signed in as "bob@example.com"
-    And the public group "Syntactic Structures"
+    Given the public group "Syntactic Structures"
     And the group "Syntactic Structures" with the following ling names:
     | ling0_name  | ling1_name  |
     | Speaker     | Sentence    |
@@ -18,6 +17,7 @@ Feature: Save searches
     | Property 2    | Speaker 2   | Western   | Demographic | 0     |
     | Property 3    | Sentence 1  | verb      | Linguistic  | 1     |
     | Property 4    | Sentence 2  | noun      | Linguistic  | 1     |
+    And I am signed in as a member of Syntactic Structures
 
   Scenario: View no saved searches
     When I go to my group searches page
@@ -51,9 +51,13 @@ Feature: Save searches
     And I select "Speaker 1" from "Speakers"
     And I select "Sentence 1" from "Sentences"
     And I press "Show results"
+    And I follow "Save Search"
     Then I should see "Save search results"
-    When I fill in "search_name" with "My First Search"
+    When I fill in "save-search-name" with "My First Search"
     And I press "Save"
+    Then I should see "Your seach has been successfully saved!"
+    When I go to the group Syntactic Structures
+    And I follow "History"
     Then I should see "Syntactic Structures Search History"
     And I should see "My First Search"
     And I should not see "My Second Search"
@@ -63,10 +67,10 @@ Feature: Save searches
     And I select "Speaker 1" from "Speakers"
     And I select "Sentence 1" from "Sentences"
     And I press "Show results"
+    And I follow "Save Search"
     Then I should see "Save search results"
-    When I fill in "search_name" with "My First Search"
+    When I fill in "save-search-name" with "My First Search"
     And I press "Save"
-    And I follow "Show results"
     Then I should see the following grouped search results:
     | parent ling | parent property | parent value  | child ling  | child property  | child value  |
     | Speaker 1   | Property 1      | Eastern       | Sentence 1  | Property 3      | verb         |
@@ -84,19 +88,18 @@ Feature: Save searches
     And I check "Value" within "#show_child"
     And I select "Speaker 1" from "Speakers"
     And I press "Show results"
+    And I follow "Save Search"
     Then I should see "Save search results"
-    When I fill in "search_name" with "My First Search"
+    When I fill in "save-search-name" with "My First Search"
     And I press "Save"
-    And I follow "Download CSV"
-    Then the csv should contain the following rows
-    | col_1     | col_2               | col_3       | col_4           |
-    | Speaker   | Speaker Properties  | Sentence    | Sentence Values |
-    | Speaker 1 | Property 1          | Sentence 1  | verb            |
+    And I press "Close Modal"
+    And I follow "Download Results"
+    Then the csv "terraling-search-results-default.csv" exists
 
   Scenario: Delete saved query
     Given I have a saved group search "My First Search"
     When I go to the Syntactic Structures search page
-    When I follow "History" within "#header"
+    And I follow "History" within "#header"
     And I follow "Delete"
     Then I should see "successfully deleted"
     And I should see "Syntactic Structures Search History"
@@ -113,15 +116,19 @@ Feature: Save searches
   Scenario: Save search at limit
     Given I have 24 saved group searches
     When I go to the Syntactic Structures search page
-    When I press "Show results"
-    And I fill in "search_name" with "Search 25"
-    Then I press "Save"
-    And I should see "Search 25"
+    And I press "Show results"
+    And I follow "Save Search"
+    And I fill in "save-search-name" with "Search 25"
+    And I press "Save"
+    And I go to the group Syntactic Structures
+    And I follow "History"
+    Then I should see "Search 25"
 
   Scenario: Error on search
     When I go to the Syntactic Structures search page
-    When I press "Show results"
-    And I fill in "search_name" with ""
+    And I press "Show results"
+    And I follow "Save Search"
+    And I fill in "save-search-name" with ""
     Then I press "Save"
     And I should see "can't be blank"
 
@@ -130,15 +137,16 @@ Feature: Save searches
     And I select "Speaker 1" from "Speakers"
     And I select "Sentence 1" from "Sentences"
     And I press "Show results"
+    And I follow "Save Search"
     Then I should see "Save search results"
-    When I fill in "search_name" with "My First Search"
+    When I fill in "save-search-name" with "My First Search"
     And I press "Save"
     Then I go to the Syntactic Structures search page
-    And I select "Speaker 2" from "Speakers"
+    When I select "Speaker 2" from "Speakers"
     And I select "Sentence 2" from "Sentences"
     And I press "Show results"
-    Then I follow "History"
-    And I follow "Show results"
+    And I follow "History"
+    And I follow "My First Search"
     Then I should see the following grouped search results:
     | parent ling | parent property | parent value  | child ling  | child property  | child value  |
     | Speaker 1   | Property 1      | Eastern       | Sentence 1  | Property 3      | verb         |
@@ -164,9 +172,8 @@ Feature: Save searches
 
   Scenario: No save option for Universal Implication Search
     When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I select "Property 1" from "Demographic Properties"
     And I select "Property 2" from "Demographic Properties"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should not see "Save search results"
-

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -194,6 +194,10 @@ Then /^the csv should contain the following rows$/ do |table|
   end
 end
 
+Then /^the csv "([^\"]*)" exists$/ do |filename|
+  expect_download_occurred(filename)
+end
+
 Then /^I should see (\d+) search result rows?$/ do |count|
   page.should have_css("tr.search_result", :count => count.to_i)
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -25,6 +25,7 @@ When /^(?:|I )go to (.+)$/ do |page_name|
 end
 
 When /^(?:|I )press "([^\"]*)"(?: within "([^\"]*)")?$/ do |button, selector|
+  button = 'close_modal' if button.eql? "Close Modal"
   with_scope(selector) do
     click_button(button, :match => :prefer_exact)
     # To fix ambiguity with Capybara 2 let's take just the first match

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -66,6 +66,7 @@ When /^(?:|I )follow "([^\"]*)"(?: within "([^\"]*)")?$/ do |link, selector|
       page.execute_script "window.scrollBy(0,-100)"
     end
     find('a', :text =>"Search").hover if link.eql?( "Advanced Search" )|| link.eql?( "History")
+    find('li#userInfo').hover if link.eql? "Sign out"
     click_link(link, :match => :prefer_exact)
 
     # To fix ambiguity with Capybara let's take just the first match

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -68,10 +68,14 @@ When /^(?:|I )follow "([^\"]*)"(?: within "([^\"]*)")?$/ do |link, selector|
     end
     find('a', :text =>"Search").hover if link.eql?( "Advanced Search" )|| link.eql?( "History")
     find('li#userInfo').hover if link.eql? "Sign out"
+
     click_link(link, :match => :prefer_exact)
 
     # To fix ambiguity with Capybara let's take just the first match
     # first(:link, link).click
+
+    #accept 'are you sure?' pop up
+    accept_alert_popup if link.eql? "Delete"
   end
 end
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -52,8 +52,12 @@ end
 
 When /^(?:|I )follow "([^\"]*)"(?: within "([^\"]*)")?$/ do |link, selector|
   with_scope(selector) do
+    link = "saveit" if link.eql? "Save Search"
+    if link.eql? "Download Results"
+      clear_directory(download_dir)
+      link = "downloadit"
+    end
     # This step is too general and ambiguious, might have to break apart
-
     if link.eql? "Syntactic Structures" && page.has_link?(:text => "Pick a Dataset")
       find('a', :text =>"Pick a Dataset").hover
     end

--- a/features/support/browser_helper.rb
+++ b/features/support/browser_helper.rb
@@ -1,0 +1,4 @@
+#need it when an alert popup shows up on the screen
+def accept_alert_popup
+  page.driver.browser.switch_to.alert.accept
+end

--- a/features/support/download_helper.rb
+++ b/features/support/download_helper.rb
@@ -1,0 +1,26 @@
+Before do
+  use_downloading_browser
+end
+
+def expect_download_occurred(filename)
+  File.exists?(File.join(download_dir, filename)).should be_truthy
+end
+
+def use_downloading_browser
+  profile = ::Selenium::WebDriver::Firefox::Profile.new
+  profile['browser.download.folderList'] = 2
+  profile['browser.download.dir'] = download_dir
+  profile['browser.helperApps.neverAsk.saveToDisk'] = "application/csv,text/csv,application/octet-stream,text/plain"
+  Capybara.register_driver :selenium_download do |app|
+    Capybara::Selenium::Driver.new(app, {:browser => :firefox, :profile => profile})
+  end
+  Capybara.current_driver = :selenium_download
+end
+
+def download_dir
+  @download_dir ||= "#{Dir.pwd}/tmp/downloads"
+end
+
+def clear_directory directory
+  FileUtils.rm_rf("#{directory}/.", secure: true)
+end


### PR DESCRIPTION
In this PR I fixed saved_search.feature.
The following problems that I fixed:
- Sign out link was invisible, so Capybara can't find it
- In Default search when results_group is nil or empty, the search crash it
- Cross Search crash when there is no result, because it doesn't be able to create the header with no result
- There is no way to close the modal
- In saved Search form when the name of search is not inserted It don't raise any error
- There is no way to close "Are you sure?" popup
- A lot of problems with CSV download
