### PR TITLE
Fixed search_by_implication_antecedent.feature

### DIFF
--- a/app/assets/javascripts/views/searches/results/results_cross.js
+++ b/app/assets/javascripts/views/searches/results/results_cross.js
@@ -133,8 +133,8 @@
 
       // columns is an array here!
       var pair_columns = table.headers;
-
-      var new_entry = {pair: [], pair_id: null, count: func_dict.count(entry)};
+      var property_value = [];
+      var new_entry = {pair: [], pair_id: null, property_value: null, count: func_dict.count(entry)};
       for( var pc=0; pc< pair_columns.length; pc++ ){
         var pair_entry = {};
         var pairId = [];
@@ -146,7 +146,9 @@
         }
         new_entry.pair.push(pair_entry);
         new_entry.pair_id = pairId.join('-');
+        property_value.push(func_dict.cross_property_id(entry, pc)+":"+func_dict.cross_value(entry, pc));
       }
+      new_entry.property_value = property_value.join('_');
 
       return new_entry;
     }

--- a/app/assets/javascripts/views/searches/results/results_cross.js
+++ b/app/assets/javascripts/views/searches/results/results_cross.js
@@ -96,10 +96,11 @@
 
     function crossMapping(table, entry, index){
       var func_dict = {
-        'count'         : getCrossLings,
-        'cross_property': getProperty('parent'),
-        'cross_value'   : getValue('parent'),
-        'row_id'        : getValueId('parent')
+        'count'            : getCrossLings,
+        'cross_property'   : getProperty('parent'),
+        'cross_property_id': getPropertyId('parent'),
+        'cross_value'      : getValue('parent'),
+        'row_id'           : getValueId('parent')
       };
 
       function getCrossLings(entry){
@@ -109,6 +110,12 @@
       function getProperty(level){
         return function (entry, i){
           return T.Util.isThere(entry, level, i, 'lings_property', 'property') ? entry[level][i].lings_property.property.name : ' ';
+        };
+      }
+
+      function getPropertyId(level){
+        return function (entry, i){
+          return T.Util.isThere(entry, level, i, 'lings_property', 'property', 'id') ? entry[level][i].lings_property.property.id : ' ';
         };
       }
 

--- a/app/assets/templates/searches/results/cross_results.hamstache
+++ b/app/assets/templates/searches/results/cross_results.hamstache
@@ -14,7 +14,7 @@
       {{/header.count}}
   %tbody
     {{#rows}}
-    %tr{:id => "{{pair_id}}" }
+    %tr{:id => "{{pair_id}}", :data => {"property-value" => "{{property_value}}" }}
       {{#pair}}
       {{#cross_property}}
       %td {{cross_property}}

--- a/features/search_by_implication_antecedent.feature
+++ b/features/search_by_implication_antecedent.feature
@@ -53,9 +53,9 @@ Feature: Search with Implication Antecedent
 
   Scenario: Visitor searches Implication Antecedent with Languages Constraints on Demographics, showing Linguistics
     When I go to the Syntactic Structures search page
+    And I choose "Antecedent" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I select "Speaker 1" from "Lings"
-    And I choose "Antecedent" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -66,9 +66,9 @@ Feature: Search with Implication Antecedent
 
   Scenario: Visitor searches Implication Antecedent with Properties Constraints on Demographic
     When I go to the Syntactic Structures search page
+    And I choose "Antecedent" within "#advanced_set"
     And I uncheck "Linglet" within "#show_impl"
     And I select "Property 3" from "Demographic Properties"
-    And I choose "Antecedent" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -114,8 +114,8 @@ Feature: Search with Implication Antecedent
 
   Scenario: Visitor searches Implication Antecedent with all Properties and Lings: should be the same as Implication Both, showing Linguistics
     When I go to the Syntactic Structures search page
-    And I uncheck "Ling" within "#show_impl"
     And I choose "Antecedent" within "#advanced_set"
+    And I uncheck "Ling" within "#show_impl"
     And I press "Show results"
     And I should not see "Speaker 1"
     And I should not see "Sentence 1"
@@ -136,16 +136,16 @@ Feature: Search with Implication Antecedent
 
   Scenario: Visitor searches a combination by Implication Antecedent expecting no results
    When I go to the Syntactic Structures search page
+    And I choose "Antecedent" within "#advanced_set"
     And I select "Property 3" from "Demographic Properties"
     And I select "Property 8" from "Linguistic Properties"
-    And I choose "Antecedent" within "#advanced_set"
     And I press "Show results"
     Then I should see no search result rows
 
   Scenario: Visitor searches and uncheck both depths for Implication Antecedent expecting no results
    When I go to the Syntactic Structures search page
+    And I choose "Antecedent" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I uncheck "Linglet" within "#show_impl"
-    And I choose "Antecedent" within "#advanced_set"
     And I press "Show results"
     Then I should see no search result rows

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -135,8 +135,8 @@ Then /^I should see the following Cross search results:$/ do |table|
     end
 
     # calculated_div_id = lps.inject("p") {|memo, lp| "#{memo}-#{lp.prop_name.hash - lp.property_value.hash}" }
-    calculated_div_id =  lps.map { |lp| "#{lp.prop_id}:#{lp.property_value}"}.join("_")
-    with_scope(%Q|[data-parent-value="#{calculated_div_id}"]|) do
+    calculated_div_id =  lps.map { |lp| "#{lp.property_value}"}.join("_")
+    with_scope(%Q|[data-property-value="#{calculated_div_id}"]|) do
       props.each do |prop|
         page.should have_content(prop.name)
       end


### PR DESCRIPTION
I solved the following problems:
- There wasn't a way to extract property id of cross search result entry
- You can't select implication options if you don't choose "antecedent" box, I inverted order of those lines
- I fixed "calculated_div_id" because there is a repetition with property id
