### PR TITLE
Fixed search_by_implication_both search_by_implication_consequent search_by_implication_double

### DIFF
--- a/features/search_by_implication_both.feature
+++ b/features/search_by_implication_both.feature
@@ -69,9 +69,9 @@ Feature: Search with Implication Both
 
   Scenario: Visitor searches Implication Both with all Demographic Properties
     When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I check "Ling" within "#show_impl"
     And I uncheck "Linglet" within "#show_impl"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -89,9 +89,9 @@ Feature: Search with Implication Both
 
   Scenario: Visitor searches Implication Both with all Linguistic Properties
     When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I check "Linglet" within "#show_impl"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -110,9 +110,9 @@ Feature: Search with Implication Both
 
   Scenario: Visitor searches Implication Both for Properties and Languages with Constraints
     When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I select "Speaker 2" from "Lings"
     And I select "Speaker 3" from "Lings"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -136,10 +136,10 @@ Feature: Search with Implication Both
 
   Scenario: Visitor searches Implication Both for Properties and Languages with Constraints, Demographic results
     When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I uncheck "Linglet" within "#show_impl"
     And I select "Speaker 2" from "Lings"
     And I select "Speaker 3" from "Lings"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -156,10 +156,10 @@ Feature: Search with Implication Both
 
   Scenario: Visitor searches Implication Both for Properties and Languages with Constraints, Linguistic results
     When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I select "Speaker 2" from "Lings"
     And I select "Speaker 3" from "Lings"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     And I should not see "Property 2"
     Then I should see the following Implication search results:
@@ -176,16 +176,16 @@ Feature: Search with Implication Both
 
   Scenario: Visitor searches a combination by Implication Both expecting no results
    When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I select "Property 1" from "Demographic Properties"
     And I select "Property 8" from "Linguistic Properties"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should see no search result rows
 
   Scenario: Visitor searches and uncheck both depths for Implication Both expecting no results
    When I go to the Syntactic Structures search page
+    And I choose "Both" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I uncheck "Linglet" within "#show_impl"
-    And I choose "Both" within "#advanced_set"
     And I press "Show results"
     Then I should see no search result rows

--- a/features/search_by_implication_consequent.feature
+++ b/features/search_by_implication_consequent.feature
@@ -61,10 +61,10 @@ Feature: Search with Implication Consequent
 
   Scenario: Visitor searches Implication Consequent with Languages Constraints on Demographic, showing Linguistics
     When I go to the Syntactic Structures search page
+    And I choose "Consequent" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I select "Speaker 2" from "Lings"
     And I select "Speaker 3" from "Lings"
-    And I choose "Consequent" within "#advanced_set"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -115,8 +115,8 @@ Feature: Search with Implication Consequent
 
   Scenario: Visitor searches Implication Consequent with all Properties and Lings: should be the same as Implication Both, showing Linguistics
     When I go to the Syntactic Structures search page
-    And I uncheck "Ling" within "#show_impl"
     And I choose "Consequent" within "#advanced_set"
+    And I uncheck "Ling" within "#show_impl"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -134,8 +134,8 @@ Feature: Search with Implication Consequent
 
   Scenario: Visitor searches and uncheck both depths for Implication Consequent expecting no results
    When I go to the Syntactic Structures search page
+    And I choose "Consequent" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I uncheck "Linglet" within "#show_impl"
-    And I choose "Consequent" within "#advanced_set"
     And I press "Show results"
     Then I should see no search result rows

--- a/features/search_by_implication_double.feature
+++ b/features/search_by_implication_double.feature
@@ -45,8 +45,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor searches Implication Double Both within Demographic
     When I go to the Syntactic Structures search page
-    And I uncheck "Linglet" within "#show_impl"
     And I choose Implication "Double" within "#advanced_set"
+    And I uncheck "Linglet" within "#show_impl"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -55,8 +55,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor searches Implication Double Both within Linguistic
     When I go to the Syntactic Structures search page
-    And I uncheck "Ling" within "#show_impl"
     And I choose Implication "Double" within "#advanced_set"
+    And I uncheck "Ling" within "#show_impl"
     And I press "Show results"
     Then I should see the following Implication search results:
     | Property Name 1 | Property Value 1 | Property Name 2 | Property Value 2 | Count |
@@ -65,8 +65,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor searches Implication Double Both within Demographic with Languages Constraints
     When I go to the Syntactic Structures search page
-    And I uncheck "Linglet" within "#show_impl"
     And I choose Implication "Double" within "#advanced_set"
+    And I uncheck "Linglet" within "#show_impl"
     And I select "Speaker 2" from "Lings"
     And I select "Speaker 3" from "Lings"
     And I press "Show results"
@@ -76,8 +76,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor scearches Implication Double both within Linguistic with Languages Constraints
     When I go to the Syntactic Structures search page
-    And I uncheck "Ling" within "#show_impl"
     And I choose Implication "Double" within "#advanced_set"
+    And I uncheck "Ling" within "#show_impl"
     And I select "Speaker 2" from "Lings"
     And I select "Speaker 3" from "Lings"
     And I press "Show results"
@@ -87,8 +87,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor searches Implication Double Both within Demographic with Properties Constraints
     When I go to the Syntactic Structures search page
-    And I uncheck "Linglet" within "#show_impl"
     And I choose Implication "Double" within "#advanced_set"
+    And I uncheck "Linglet" within "#show_impl"
     And I select "Property 2" from "Demographic Properties"
     And I select "Property 4" from "Demographic Properties"
     And I press "Show results"
@@ -98,8 +98,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor searches Implication Double both within Linguistic with Properties Constraints
     When I go to the Syntactic Structures search page
-    And I uncheck "Ling" within "#show_impl"
     And I choose Implication "Double" within "#advanced_set"
+    And I uncheck "Ling" within "#show_impl"
     And I select "Property 5" from "Linguistic Properties"
     And I select "Property 6" from "Linguistic Properties"
     And I press "Show results"
@@ -109,8 +109,8 @@ Feature: Search with Double Both Implication
 
   Scenario: Visitor searches and uncheck both depths for Implication Double Both expecting no results
    When I go to the Syntactic Structures search page
+    And I choose Implication "Double" within "#advanced_set"
     And I uncheck "Ling" within "#show_impl"
     And I uncheck "Linglet" within "#show_impl"
-    And I choose Implication "Double" within "#advanced_set"
     And I press "Show results"
     Then I should see no search result rows


### PR DESCRIPTION
In all these features the problem is the same:
- The order of steps is wrong. it need to choose the main box in "#advanced_set" before the others options otherwise the options can not be clicked because they are hidden
