### PR TITLE
Run cucumber tests again on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
 - phantomjs --version
 script:
 - RAILS_ENV=test bundle exec rspec spec
+- RAILS_ENV=test bundle exec cucumber --profile travis
 rvm:
 - 1.9.3
 - 2.0.0


### PR DESCRIPTION
This PR will re-introduce the Cucumber test in the continuous integration environment loop.

They have been removed some time ago when migrating from one Rails version to another as the entire testing infrastructure was fallen apart.
The `spec` one is now back and working and the `cucumber` one is getting better, so it's time to restore it.
