### PR TITLE
Force the usage of ruby 1.9.3 directly in deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,10 @@ before_deploy:
 - eval "$(ssh-agent -s)"
 - chmod 600 /tmp/deploy_rsa
 - ssh-add /tmp/deploy_rsa
-- rvm use 1.9.3 --install --binary --fuzzy
 deploy:
   provider: script
   skip_cleanup: true
-  script: ruby -v && bundle install --without development production test && bundle exec cap travisci deploy
+  script: rvm use 1.9.3 --install --binary --fuzzy && bundle install --without development production test && bundle exec cap travisci deploy
   on:
     branch: sprint
     rvm: 1.9.3


### PR DESCRIPTION
The deploy part of travis uses a different ruby for some odd reason. Lets use 1.9.3