### PR TITLE
Added (hacky) fix for Rails JSON deserialization behavior that was br…

### DIFF
--- a/app/assets/javascripts/views/searches/preview.js
+++ b/app/assets/javascripts/views/searches/preview.js
@@ -96,7 +96,7 @@
           setBar(100, "An Error occurred on the server");
         } else {
           // show something
-          $('#results_loading_text').text( "The search it's taking longer than expected...");
+          $('#results_loading_text').text( "The search is taking longer than expected...");
         }
       }
     }

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -155,9 +155,11 @@ class SearchesController < GroupDataController
     redirect_to :action => :new
   end
 
-  def perform_search(offset=0)
-    result_groups = {}
+  def convert_result_groups(params)
+    # If result_groups hash is not nil, converts any empty string values into
+    # empty lists. This is to work around a bug in how Rails munges JSON.
     if not params[:result_groups].nil?
+      result_groups = {}
       params[:result_groups].each do |key, value|
         if value.blank?
           result_groups[key] = []
@@ -165,7 +167,15 @@ class SearchesController < GroupDataController
           result_groups[key] = value
         end
       end
+    else
+      result_groups = nil
     end
+    return result_groups
+  end
+
+  def perform_search(offset=0)
+    result_groups = convert_result_groups params
+
     Search.new do |s|
       s.creator = current_user
       s.group         = current_group

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -156,13 +156,23 @@ class SearchesController < GroupDataController
   end
 
   def perform_search(offset=0)
+    result_groups = {}
+    if not params[:result_groups].nil?
+      params[:result_groups].each do |key, value|
+        if value.blank?
+          result_groups[key] = []
+        else
+          result_groups[key] = value
+        end
+      end
+    end
     Search.new do |s|
       s.creator = current_user
       s.group         = current_group
       s.query         = params[:search]
       #the only way to calculate a compare search is passing the result group param,
       #without it compare search will calculate a wrong result.
-      s.result_groups = params[:result_groups]
+      s.result_groups = result_groups
       s.offset        = offset
     end
   end

--- a/app/models/search_results/comparisons.rb
+++ b/app/models/search_results/comparisons.rb
@@ -5,11 +5,7 @@ module SearchResults
     def result_rows=(result_rows)
       self.result_groups = result_rows.group_by { |row| row.parent_id }
       self.result_groups.values.map! { |row| row.map! { |r| r.child_id }.compact! }
-      self.result_groups.each do |key, value|
-        if value.empty?
-          self.result_groups[key] = nil
-        end
-      end
+      self.result_groups.each { |key, value| self.result_groups[key] = value.empty? ? nil : value }
       @search_comparison = true
     end
 

--- a/app/models/search_results/comparisons.rb
+++ b/app/models/search_results/comparisons.rb
@@ -5,6 +5,11 @@ module SearchResults
     def result_rows=(result_rows)
       self.result_groups = result_rows.group_by { |row| row.parent_id }
       self.result_groups.values.map! { |row| row.map! { |r| r.child_id }.compact! }
+      self.result_groups.each do |key, value|
+        if value.empty?
+          self.result_groups[key] = nil
+        end
+      end
       @search_comparison = true
     end
 


### PR DESCRIPTION
…eaking comparison searches. Fixed a small grammar error.

Gory details:

You can trigger this bug by saving at least two searches, going to Search > History, and then choosing one of the actions over the two searches defined at the bottom (it doesn't matter which). The bug is that regardless of what you do, the results are just the results of the first of the two saved searches.

The issue has to do with JSON deserialization in Rails. Take the intersection search comparison for example. The comparison works by:

- Running both of the searches independently and intersecting the rows of each

- Rendering a new search object whose "result_groups" parameter is the rows generated by the previous step, and whose query is just the query for the first search.

- This new search object gets passed to the renderer and eventually ends up in the hands of preview.js, where a JSON object is created holding both the query and the result rows and is passed in a POST back to the (non-comparative) search controller. It looks like the search controller will just use the results in result_groups if it exits, and will otherwise run the specified query on the database.

This is where things go wrong. There's a step when the search object is being built where the search rows are converted into a hash with parent IDs as the keys and child IDs as the values. If the rows have no child values, we get a hash that looks like this:

{"4681"=>[], "4683"=>[]}

The JSON that ends up being passed into the POST in preview.js looks similar. When Rails deserializes the JSON, it eliminates fields that are nil or []. I think this is related to the "deep munging" Rails does. I don't know exactly how this process works on hashes, but in practice it doesn't seem to care that we have keys. Because there are only empty values, what ends up happening is result_groups gets completely erased. This means that the search controller gets no result_groups, and just ends up running the first query (again) and returning just the results from that.

I think there are ways to mitigate this behavior in server config or controller settings, but because Terraling is running such an ancient version of Rails, none of them are available.

I pushed a fix for this that I'm not proud of, but it appears to work. It converts the empty arrays pre-serialization into empty strings, and then converts empty strings post-deserialization back into empty arrays. The searches I've run locally work as expected now. I don't really know Ruby or Rails very well, so sorry if this isn't a good solution or if I haven't coded something very elegantly.

For what it's worth, I also tried setting comparison search to return static results (I think this functionality broke whenever dynamic results were introduced), but this broke a bunch of other things.

Please take a look and let me know what you think.