### PR TITLE
Map pin colors correspond with rows in results

### DIFF
--- a/app/assets/javascripts/views/searches/results/results_cross.js
+++ b/app/assets/javascripts/views/searches/results/results_cross.js
@@ -31,15 +31,12 @@
     //associated with that row.  This allows us to color
     //lings based on their row in getStyler().
     var rows_by_ling = {}
-    if (resultsJson) {
-      var json_rows = resultsJson.rows;
-      for (var i = 0; i < json_rows.length; i++) {
-	var row_child = json_rows[i].child;
-        for (var j = 0; j < row_child.length; j++) {
-          rows_by_ling[row_child[j].lings_property.ling_id] = i;
-        }
-      }
-    }
+    resultsJson.rows.forEach( function(row, i){
+      row.child.forEach( function(child){
+        rows_by_ling[child.lings_property.ling_id] = i;
+      });
+    });    
+
 
     function bindLingsModal(){
       // dynamically bind count links to show a modal with the lings

--- a/app/assets/javascripts/views/searches/results/results_cross.js
+++ b/app/assets/javascripts/views/searches/results/results_cross.js
@@ -223,28 +223,31 @@
 
       var colors_by_row = {};
 
-      //modified section
+      // associates a color with each id based on row
+      // if no color yet associated w/ a row, assign one
+      // works up to 20 colors.  Then we run out (TODO: fix) 
+      function getColorById(id){
+        if(!colors_by_row[rows_by_ling[id]]){
+          if(counter < 20){
+            colors_by_row[rows_by_ling[id]] = colors[counter++];
+          }
+        }
+        return colors_by_row[rows_by_ling[id]];
+      }
+
       function styler(entry) {
-        if(colors_by_row[rows_by_ling[entry.id]]) {
-          return {
-            markerColor: colors[colors_by_row[rows_by_ling[entry.id]]],
-            iconColor: 'white',
-            icon: 'info',
-            text: popups[entry.id]
-          }
-        } else if (++counter < 20) { //color for this row hasn't been assigned yet
-          colors_by_row[rows_by_ling[entry.id]] = counter;
-          return {
-            markerColor: colors[counter],
-            iconColor: 'white',
-            icon: 'info',
-            text: popups[entry.id]
-          }
-        } else { //there are no colors left for this row to use.  oh no.
-          return null;
-        } 
-    }
-    //end modified section
+        var entry_color = getColorById(entry.id);
+        if (entry_color == null) {
+          return null
+        }
+        return {
+          markerColor: entry_color,
+          iconColor: 'white',
+          icon: 'info',
+          text: popups[entry.id]
+        };
+      } 
+ 
     return styler;
   }
 

--- a/app/assets/javascripts/views/searches/results/results_cross.js
+++ b/app/assets/javascripts/views/searches/results/results_cross.js
@@ -26,6 +26,21 @@
       setupModal = true;
     }
 
+    //hash-like object to get the lings colored correctly.
+    //hashes the rows of the cross search by ling-ids
+    //associated with that row.  This allows us to color
+    //lings based on their row in getStyler().
+    var rows_by_ling = {}
+    if (resultsJson) {
+      var json_rows = resultsJson.rows;
+      for (var i = 0; i < json_rows.length; i++) {
+	var row_child = json_rows[i].child;
+        for (var j = 0; j < row_child.length; j++) {
+          rows_by_ling[row_child[j].lings_property.ling_id] = i;
+        }
+      }
+    }
+
     function bindLingsModal(){
       // dynamically bind count links to show a modal with the lings
       $(document).on('click', '[id^="lings_cross_"]', showLingsModal);
@@ -206,16 +221,32 @@
 
       var popups = preparePopup(resultsJson);
 
-      function styler(entry){
-        return counter < 20 ? {
-          markerColor: colors[counter++],
-          iconColor: 'white',
-          icon: 'info',
-          text: popups[entry.id]
-        } : null;
-      }
-      return styler;
+      var colors_by_row = {};
+
+      //modified section
+      function styler(entry) {
+        if(colors_by_row[rows_by_ling[entry.id]]) {
+          return {
+            markerColor: colors[colors_by_row[rows_by_ling[entry.id]]],
+            iconColor: 'white',
+            icon: 'info',
+            text: popups[entry.id]
+          }
+        } else if (++counter < 20) { //color for this row hasn't been assigned yet
+          colors_by_row[rows_by_ling[entry.id]] = counter;
+          return {
+            markerColor: colors[counter],
+            iconColor: 'white',
+            icon: 'info',
+            text: popups[entry.id]
+          }
+        } else { //there are no colors left for this row to use.  oh no.
+          return null;
+        } 
     }
+    //end modified section
+    return styler;
+  }
 
     function preparePopup(json){
       // get the template now


### PR DESCRIPTION
When geomapping a cross-search, the color of the map pins now correspond to rows in the search results.  This is done by creating a mapping between lings and the rows that they appear in, and another mapping between colors and the row that they correspond to.

This fix partially remedies the existing problem that the map will stop laying pins when it runs out of colors, since there are typically many lings per row, and often fewer than 20 (max number of colors) rows.  The solution is not scalable, however, and large cross-searches still fail to display all map-pins.